### PR TITLE
Removing the downsampling layers in Large ResNets to fit CIFAR setup

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -1,4 +1,3 @@
-from bdb import effective
 import os
 import sys
 

--- a/objective.py
+++ b/objective.py
@@ -17,6 +17,9 @@ with safe_import_context() as import_ctx:
     AugmentedDataset = import_ctx.import_from(
         'torch_helper', 'AugmentedDataset'
     )
+    remove_initial_downsample = import_ctx.import_from(
+        'torch_resnets', 'remove_initial_downsample'
+    )
     TFResNet18 = import_ctx.import_from('tf_resnets', 'ResNet18')
     TFResNet34 = import_ctx.import_from('tf_resnets', 'ResNet34')
     TFResNet50 = import_ctx.import_from('tf_resnets', 'ResNet50')
@@ -49,6 +52,8 @@ class Objective(BaseObjective):
 
     name = "ConvNet classification fitting"
     is_convex = False
+
+    image_width_cutout = 128
 
     install_cmd = 'conda'
     requirements = [
@@ -89,12 +94,11 @@ class Objective(BaseObjective):
 
             # For now 128 is an arbitrary number
             # to differentiate big and small images
-            if self.width < 128:
+            if self.width < self.image_width_cutout:
                 input_width = 4*self.width
                 add_kwargs['no_initial_downsample'] = True
             else:
                 add_kwargs['no_initial_downsample'] = False
-
 
         def _model_init_fn():
             model = model_klass(
@@ -112,6 +116,10 @@ class Objective(BaseObjective):
 
         def _model_init_fn():
             model = model_klass(num_classes=self.n_classes)
+            is_resnet = self.model_type == 'resnet'
+            is_small_images = self.width < self.image_width_cutout
+            if is_resnet and is_small_images:
+                model = remove_initial_downsample(model)
             return BenchPLModule(model)
         return _model_init_fn
 

--- a/objective.py
+++ b/objective.py
@@ -83,17 +83,18 @@ class Objective(BaseObjective):
     def get_tf_model_init_fn(self):
         model_klass = TF_MODEL_MAP[self.model_type][self.model_size]
         add_kwargs = {}
+        input_width = self.width
         if self.model_type == 'resnet':
             add_kwargs['use_bias'] = False
 
-        # For now 128 is an arbitrary number
-        # to differentiate big and small images
-        if self.width < 128:
-            input_width = 4*self.width
-            no_initial_downsample = True
-        else:
-            input_width = self.width
-            no_initial_downsample = False
+            # For now 128 is an arbitrary number
+            # to differentiate big and small images
+            if self.width < 128:
+                input_width = 4*self.width
+                add_kwargs['no_initial_downsample'] = True
+            else:
+                add_kwargs['no_initial_downsample'] = False
+
 
         def _model_init_fn():
             model = model_klass(
@@ -101,7 +102,6 @@ class Objective(BaseObjective):
                 classes=self.n_classes,
                 classifier_activation='softmax',
                 input_shape=(input_width, input_width, 3),
-                no_initial_downsample=no_initial_downsample,
                 **add_kwargs,
             )
             return model

--- a/objective.py
+++ b/objective.py
@@ -1,3 +1,4 @@
+from bdb import effective
 import os
 import sys
 
@@ -86,12 +87,22 @@ class Objective(BaseObjective):
         if self.model_type == 'resnet':
             add_kwargs['use_bias'] = False
 
+        # For now 128 is an arbitrary number
+        # to differentiate big and small images
+        if self.width < 128:
+            input_width = 4*self.width
+            no_initial_downsample = True
+        else:
+            input_width = self.width
+            no_initial_downsample = False
+
         def _model_init_fn():
             model = model_klass(
                 weights=None,
                 classes=self.n_classes,
                 classifier_activation='softmax',
-                input_shape=(self.width, self.width, 3),
+                input_shape=(input_width, input_width, 3),
+                no_initial_downsample=no_initial_downsample,
                 **add_kwargs,
             )
             return model

--- a/utils/tf_resnets.py
+++ b/utils/tf_resnets.py
@@ -194,7 +194,7 @@ def remove_initial_downsample(large_model, use_bias=False):
         use_bias=use_bias,
         name='conv1_conv',
     )
-    input_shape = large_model.input_shape[1:]
+    input_shape = list(large_model.input_shape[1:])
     input_shape[0] = input_shape[0] // 4
     input_shape[1] = input_shape[1] // 4
     small_model = models.Sequential([

--- a/utils/tf_resnets.py
+++ b/utils/tf_resnets.py
@@ -194,8 +194,11 @@ def remove_initial_downsample(large_model, use_bias=False):
         use_bias=use_bias,
         name='conv1_conv',
     )
+    input_shape = large_model.input_shape[1:]
+    input_shape[0] = input_shape[0] // 4
+    input_shape[1] = input_shape[1] // 4
     small_model = models.Sequential([
-        layers.Input((32, 32, 3)),
+        layers.Input(input_shape),
         first_conv,
         layers.BatchNormalization(axis=-1, epsilon=1.001e-5, name='conv1_bn'),
         layers.Activation('relu', name='conv1_relu'),

--- a/utils/torch_resnets.py
+++ b/utils/torch_resnets.py
@@ -1,0 +1,17 @@
+from benchopt import safe_import_context
+
+with safe_import_context() as import_ctx:
+    import torch
+
+
+def remove_initial_downsample(large_model):
+    large_model.conv1 = torch.nn.Conv2d(
+        3,
+        64,
+        kernel_size=3,
+        stride=1,
+        padding=3,
+        bias=False,
+    )
+    large_model.maxpool = torch.nn.Identity()
+    return large_model


### PR DESCRIPTION
This should tackle the point raised here: https://github.com/benchopt/benchmark_resnet_classif/issues/2#issuecomment-1114799178