### PR TITLE
Benchopt install with pytorch name

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -57,7 +57,7 @@ class Objective(BaseObjective):
 
     install_cmd = 'conda'
     requirements = [
-        'pip:pytorch', 'pip:torchvision', 'pip:pytorch-lightning ',
+        'pip:torch', 'pip:torchvision', 'pip:pytorch-lightning ',
         'pip:tensorflow',
     ]
 


### PR DESCRIPTION
Currently the output for `benchopt install` returns `Exception: You tried to install "pytorch". The package named for PyTorch is "torch"
`
- If we use pip the name for pytorch is `torch`.
- If we use conda the name is `pytorch`. 

To fit with the current code I stayed with the `pip` convention.