### PR TITLE
Allowed to run a benchmark without a validation split

### DIFF
--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -48,6 +48,7 @@ class Dataset(BaseDataset):
         train_frac=0.8,
         framework="pytorch",
         random_state=27,
+        with_validation=True,
     ):
         # Store the parameters of the dataset
         self.n_samples = n_samples
@@ -58,6 +59,7 @@ class Dataset(BaseDataset):
         self.framework = framework
         self.random_state = random_state
         self.rng = np.random.default_rng(self.random_state)
+        self.with_validation = with_validation
 
     def get_np_data(self):
         n_train_and_val = int(self.n_samples * self.train_and_val_frac)

--- a/objective.py
+++ b/objective.py
@@ -241,9 +241,10 @@ class Objective(BaseObjective):
             results[dataset_name + "_err"] = 1 - metrics[acc_name]
 
         if self.with_validation:
-            results["value"] = results["val_err"]
+            value_key = "val_err"
         else:
-            results["value"] = results["train_loss"]
+            value_key = "train_loss"
+        results["value"] = results[value_key]
         return results
 
     def eval_torch(self, model, dataloader):

--- a/tests/test_dataset_consistency.py
+++ b/tests/test_dataset_consistency.py
@@ -81,8 +81,14 @@ def test_datasets_consistency(dataset_module_name, dataset_type):
         svhn,
     )
     dataset = eval(dataset_module_name)
-    d_tf = dataset.Dataset.get_instance(framework='tensorflow')
-    d_torch = dataset.Dataset.get_instance(framework='pytorch')
+    d_tf = dataset.Dataset.get_instance(
+        framework='tensorflow',
+        with_validation=True,
+    )
+    d_torch = dataset.Dataset.get_instance(
+        framework='pytorch',
+        with_validation=True,
+    )
     tf_data = d_tf.get_data()
     torch_data = d_torch.get_data()
 


### PR DESCRIPTION
In this case should we do the early stopping on the train or on the test?

The thing is that in pytorch-cifar, they do not really do an early stopping, they just report the best test acc.

Also added multiple random states in the dataset.