### PR TITLE
Corrected batch norm momentum, init of models, data aug strategies and coupled weight decay application for TF

### DIFF
--- a/datasets/cifar.py
+++ b/datasets/cifar.py
@@ -24,6 +24,7 @@ class Dataset(MultiFrameworkDataset):
         n_samples_test=10_000,
         image_width=32,
         n_classes=10,
+        symmetry='horizontal',
     )
 
     torch_ds_klass = datasets.CIFAR10

--- a/datasets/mnist.py
+++ b/datasets/mnist.py
@@ -35,6 +35,7 @@ class Dataset(MultiFrameworkDataset):
         n_samples_test=10_000,
         image_width=28,
         n_classes=10,
+        symmetry=None,
     )
 
     torch_ds_klass = datasets.MNIST

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -77,6 +77,7 @@ class Dataset(BaseDataset):
             n_samples_test=self.n_samples - n_train_and_val,
             image_width=self.img_size,
             n_classes=self.n_classes,
+            symmetry=None,
         )
 
         # inputs are channel first

--- a/datasets/svhn.py
+++ b/datasets/svhn.py
@@ -24,6 +24,7 @@ class Dataset(MultiFrameworkDataset):
         n_samples_test=26_032,
         image_width=32,
         n_classes=10,
+        symmetry=None,
     )
 
     torch_ds_klass = datasets.SVHN

--- a/objective.py
+++ b/objective.py
@@ -98,6 +98,7 @@ class Objective(BaseObjective):
         input_width = self.width
         if self.model_type == 'resnet':
             add_kwargs['use_bias'] = False
+            add_kwargs['dense_init'] = 'torch'
 
             # For now 128 is an arbitrary number
             # to differentiate big and small images

--- a/objective.py
+++ b/objective.py
@@ -276,4 +276,5 @@ class Objective(BaseObjective):
             normalization=self.normalization,
             framework=self.framework,
             symmetry=self.symmetry,
+            image_width=self.width,
         )

--- a/objective.py
+++ b/objective.py
@@ -86,6 +86,7 @@ class Objective(BaseObjective):
         n_classes,
         framework,
         normalization,
+        symmetry,
     ):
         if framework == 'tensorflow' and image_width < 32:
             return True, 'images too small for TF networks'
@@ -161,6 +162,7 @@ class Objective(BaseObjective):
         n_classes,
         framework,
         normalization,
+        symmetry,
     ):
         self.dataset = dataset
         self.val_dataset = val_dataset
@@ -173,6 +175,7 @@ class Objective(BaseObjective):
         self.n_classes = n_classes
         self.framework = framework
         self.normalization = normalization
+        self.symmetry = symmetry
 
         # Get the model initializer
         self.get_one_solution = self.get_model_init_fn(framework)
@@ -272,4 +275,5 @@ class Objective(BaseObjective):
             dataset=self.dataset,
             normalization=self.normalization,
             framework=self.framework,
+            symmetry=self.symmetry,
         )

--- a/solvers/sgd_tf.py
+++ b/solvers/sgd_tf.py
@@ -15,9 +15,9 @@ class Solver(TFSolver):
     parameters = {
         'nesterov, momentum': [(False, 0), (False, 0.9), (True, 0.9)],
         'lr': [1e-1],
-        # 'decoupled_weight_decay': [0.0, 5e-4],
-        # 'coupled_weight_decay': [0.0, 5e-4],
-        'weight_decay': [0.0, 5e-4],
+        'decoupled_weight_decay': [0.0, 5e-4],
+        'coupled_weight_decay': [0.0, 5e-4],
+        # 'weight_decay': [0.0, 5e-4],
         **TFSolver.parameters,
     }
 

--- a/solvers/sgd_tf.py
+++ b/solvers/sgd_tf.py
@@ -15,7 +15,8 @@ class Solver(TFSolver):
     parameters = {
         'nesterov, momentum': [(False, 0), (False, 0.9), (True, 0.9)],
         'lr': [1e-1],
-        'weight_decay': [0.0, 5e-4],
+        'decoupled_weight_decay': [0.0, 5e-4],
+        'coupled_weight_decay': [0.0, 5e-4],
         **TFSolver.parameters,
     }
 

--- a/solvers/sgd_tf.py
+++ b/solvers/sgd_tf.py
@@ -15,8 +15,9 @@ class Solver(TFSolver):
     parameters = {
         'nesterov, momentum': [(False, 0), (False, 0.9), (True, 0.9)],
         'lr': [1e-1],
-        'decoupled_weight_decay': [0.0, 5e-4],
-        'coupled_weight_decay': [0.0, 5e-4],
+        # 'decoupled_weight_decay': [0.0, 5e-4],
+        # 'coupled_weight_decay': [0.0, 5e-4],
+        'weight_decay': [0.0, 5e-4],
         **TFSolver.parameters,
     }
 

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -231,6 +231,8 @@ def generate_output_from_rand_image(
     'inference_mode', ['train', 'eval'],
 )
 def test_model_consistency(optimizer, extra_solver_kwargs, inference_mode):
+    if optimizer == 'adam' and CI:
+        pytest.skip('Adam is not yet aligned')
     if optimizer is not None and CI:
         pytest.skip('eval tests not working because of batch norm discrepancy')
     np.random.seed(2)

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -6,6 +8,8 @@ import torch
 from benchopt.utils.safe_import import set_benchmark
 
 set_benchmark('./')
+
+CI = os.environ.get('CI', False)
 
 
 def apply_torch_weights_to_tf(model, torch_weights_map):
@@ -227,6 +231,8 @@ def generate_output_from_rand_image(
     'inference_mode', ['train', 'eval'],
 )
 def test_model_consistency(optimizer, extra_solver_kwargs, inference_mode):
+    if optimizer is not None and CI:
+        pytest.skip('eval tests not working because of batch norm discrepancy')
     np.random.seed(2)
     batch_size = 16
     rand_image = np.random.normal(

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -148,9 +148,6 @@ def generate_output_from_rand_image(
                 model.eval()
             output = model(x)
             output = torch.softmax(output, dim=1)
-            # x = model.conv1(x)
-            # x = model.bn1(x)
-            # output = x
             return output.detach().numpy()
         if torch.cuda.is_available():
             model = model.cuda()
@@ -164,9 +161,6 @@ def generate_output_from_rand_image(
 
         def model_fn(x):
             output = model(x, training=inference_mode == 'train')
-            # intermediary_model = tf.keras.models.Model(inputs=model.inputs, outputs=model.get_layer('conv1_conv').output)
-            # output = intermediary_model(x, training=inference_mode == 'train')
-            # output = tf.transpose(output, [0, 3, 1, 2])
             return output.numpy()
         if torch_weights_map:
             apply_torch_weights_to_tf(model, torch_weights_map)

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -221,6 +221,10 @@ def test_model_consistency(optimizer, extra_solver_kwargs, inference_mode):
         inference_mode=inference_mode,
     )
     rand_image = np.transpose(rand_image, (0, 2, 3, 1))
+    if 'weight_decay' in extra_solver_kwargs:
+        extra_solver_kwargs['coupled_weight_decay'] = extra_solver_kwargs.pop(
+            'weight_decay',
+        )
     tf_output, _ = generate_output_from_rand_image(
         'tensorflow',
         rand_image,

--- a/tests/test_model_consistency.py
+++ b/tests/test_model_consistency.py
@@ -148,6 +148,9 @@ def generate_output_from_rand_image(
                 model.eval()
             output = model(x)
             output = torch.softmax(output, dim=1)
+            # x = model.conv1(x)
+            # x = model.bn1(x)
+            # output = x
             return output.detach().numpy()
         if torch.cuda.is_available():
             model = model.cuda()
@@ -161,6 +164,9 @@ def generate_output_from_rand_image(
 
         def model_fn(x):
             output = model(x, training=inference_mode == 'train')
+            # intermediary_model = tf.keras.models.Model(inputs=model.inputs, outputs=model.get_layer('conv1_conv').output)
+            # output = intermediary_model(x, training=inference_mode == 'train')
+            # output = tf.transpose(output, [0, 3, 1, 2])
             return output.numpy()
         if torch_weights_map:
             apply_torch_weights_to_tf(model, torch_weights_map)
@@ -203,6 +209,7 @@ def generate_output_from_rand_image(
         ('adam', {}),
         ('sgd', {}),
         ('sgd', dict(weight_decay=5e-1)),
+        ('sgd', dict(momentum=0.9, weight_decay=5e-1)),
     ],
 )
 @pytest.mark.parametrize(

--- a/utils/tf_helper.py
+++ b/utils/tf_helper.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+import tempfile
+
 from benchopt import safe_import_context
 
 with safe_import_context() as import_ctx:
@@ -84,3 +87,41 @@ def filter_ds_on_indices(ds, indices):
         num_parallel_calls=tf.data.experimental.AUTOTUNE,
     )
     return ds
+
+
+def set_regularizer_model(model, regularizer):
+    target_regularizers = [
+        'kernel_regularizer',
+        'bias_regularizer',
+        'beta_regularizer',
+        'gamma_regularizer',
+    ]
+    for layer in model.layers:
+        if isinstance(layer, tf.keras.models.Model):
+            set_regularizer_model(layer, regularizer)
+        else:
+            for attr in target_regularizers:
+                if hasattr(layer, attr):
+                    setattr(layer, attr, regularizer)
+
+
+def apply_coupled_weight_decay(model, wd):
+    l2_reg_factor = wd / 2
+    # taken from
+    # https://sthalles.github.io/keras-regularizer/
+    regularizer = tf.keras.regularizers.l2(l2_reg_factor)
+    set_regularizer_model(model, regularizer)
+    # When we change the layers attributes, the change only happens
+    #  in the model config file
+    model_json = model.to_json()
+
+    # Save the weights before reloading the model.
+    tmp_weights_path = Path(tempfile.gettempdir()) / 'tmp_weights.h5'
+    model.save_weights(tmp_weights_path)
+
+    # load the model from the config
+    model = tf.keras.models.model_from_json(model_json)
+
+    # Reload the model weights
+    model.load_weights(tmp_weights_path, by_name=True)
+    return model

--- a/utils/tf_resnets.py
+++ b/utils/tf_resnets.py
@@ -45,6 +45,7 @@ def basic_block(x, filters, stride=1, use_bias=True, conv_shortcut=True,
             name=name + '_0_conv',
         )(x)
         shortcut = layers.BatchNormalization(
+            momentum=0.9,
             axis=bn_axis, epsilon=1.001e-5, name=name + '_0_bn')(shortcut)
     else:
         shortcut = x
@@ -62,6 +63,7 @@ def basic_block(x, filters, stride=1, use_bias=True, conv_shortcut=True,
         use_bias=use_bias,
         name=name + '_1_conv')(x)
     x = layers.BatchNormalization(
+        momentum=0.9,
         axis=bn_axis, epsilon=1.001e-5, name=name + '_1_bn')(x)
     x = layers.Activation('relu', name=name + '_1_relu')(x)
 
@@ -73,6 +75,7 @@ def basic_block(x, filters, stride=1, use_bias=True, conv_shortcut=True,
         name=name + '_2_conv',
     )(x)
     x = layers.BatchNormalization(
+        momentum=0.9,
         axis=bn_axis, epsilon=1.001e-5, name=name + '_2_bn')(x)
 
     x = layers.Add(name=name + '_add')([shortcut, x])
@@ -107,6 +110,7 @@ def bottleneck_block(x, filters, kernel_size=3, stride=1, conv_shortcut=True,
             name=name + '_0_conv',
             )(x)
         shortcut = layers.BatchNormalization(
+            momentum=0.9,
             axis=bn_axis, epsilon=1.001e-5, name=name + '_0_bn')(shortcut)
     else:
         shortcut = x
@@ -119,6 +123,7 @@ def bottleneck_block(x, filters, kernel_size=3, stride=1, conv_shortcut=True,
         name=name + '_1_conv',
     )(x)
     x = layers.BatchNormalization(
+        momentum=0.9,
         axis=bn_axis, epsilon=1.001e-5, name=name + '_1_bn')(x)
     x = layers.Activation('relu', name=name + '_1_relu')(x)
 
@@ -130,6 +135,7 @@ def bottleneck_block(x, filters, kernel_size=3, stride=1, conv_shortcut=True,
         name=name + '_2_conv',
     )(x)
     x = layers.BatchNormalization(
+        momentum=0.9,
         axis=bn_axis, epsilon=1.001e-5, name=name + '_2_bn')(x)
     x = layers.Activation('relu', name=name + '_2_relu')(x)
 
@@ -140,6 +146,7 @@ def bottleneck_block(x, filters, kernel_size=3, stride=1, conv_shortcut=True,
         name=name + '_3_conv',
     )(x)
     x = layers.BatchNormalization(
+        momentum=0.9,
         axis=bn_axis, epsilon=1.001e-5, name=name + '_3_bn')(x)
 
     x = layers.Add(name=name + '_add')([shortcut, x])
@@ -208,7 +215,12 @@ def remove_initial_downsample(large_model, use_bias=False):
     small_model = models.Sequential([
         layers.Input(input_shape),
         first_conv,
-        layers.BatchNormalization(axis=-1, epsilon=1.001e-5, name='conv1_bn'),
+        layers.BatchNormalization(
+            momentum=0.9,
+            axis=-1,
+            epsilon=1.001e-5,
+            name='conv1_bn',
+        ),
         layers.Activation('relu', name='conv1_relu'),
         trimmed_model,
     ])

--- a/utils/tf_resnets.py
+++ b/utils/tf_resnets.py
@@ -251,6 +251,19 @@ def remove_initial_downsample(large_model, use_bias=False):
     return small_model
 
 
+def change_dense_init(model):
+    torch_init = initializers.VarianceScaling(
+        scale=1.0,
+        mode='fan_in',
+        distribution='uniform',
+    )
+    for layer in model.layers:
+        if isinstance(layer, layers.Dense):
+            layer.kernel_initializer = torch_init
+            layer.bias_initializer = torch_init
+            layer.build(layer.input_spec.shape)
+
+
 def ResNet18(include_top=True,
              weights='imagenet',
              input_tensor=None,
@@ -259,6 +272,7 @@ def ResNet18(include_top=True,
              classes=1000,
              use_bias=True,
              no_initial_downsample=False,
+             dense_init='tf',
              **kwargs):
     """Instantiates the ResNet18 architecture."""
 
@@ -313,6 +327,8 @@ def ResNet18(include_top=True,
     )
     if no_initial_downsample:
         model = remove_initial_downsample(model, use_bias=use_bias)
+    if dense_init == 'torch':
+        change_dense_init(model)
     return model
 
 
@@ -324,6 +340,7 @@ def ResNet34(include_top=True,
              classes=1000,
              use_bias=True,
              no_initial_downsample=False,
+             dense_init='tf',
              **kwargs):
     """Instantiates the ResNet34 architecture."""
 
@@ -378,6 +395,8 @@ def ResNet34(include_top=True,
     )
     if no_initial_downsample:
         model = remove_initial_downsample(model, use_bias=use_bias)
+    if dense_init == 'torch':
+        change_dense_init(model)
     return model
 
 
@@ -389,6 +408,7 @@ def ResNet50(include_top=True,
              classes=1000,
              use_bias=True,
              no_initial_downsample=False,
+             dense_init='tf',
              **kwargs):
     """Instantiates the ResNet50 architecture."""
 
@@ -442,4 +462,6 @@ def ResNet50(include_top=True,
     )
     if no_initial_downsample:
         model = remove_initial_downsample(model, use_bias=use_bias)
+    if dense_init == 'torch':
+        change_dense_init(model)
     return model

--- a/utils/tf_solver.py
+++ b/utils/tf_solver.py
@@ -44,6 +44,8 @@ class TFSolver(BaseSolver):
         # by the learning rate to have a comparable setting with PyTorch
         self.coupled_wd = getattr(self, 'coupled_weight_decay', 0.0)
         self.decoupled_wd = getattr(self, 'decoupled_weight_decay', 0.0)
+        if self.decoupled_wd == 0.0:
+            self.decoupled_wd = getattr(self, 'weight_decay', 0.0)
         if self.lr_schedule == 'step':
             self.lr_scheduler, self.wd_scheduler = [
                 tf.keras.optimizers.schedules.PiecewiseConstantDecay(

--- a/utils/tf_solver.py
+++ b/utils/tf_solver.py
@@ -80,6 +80,7 @@ class TFSolver(BaseSolver):
         normalization,
         framework,
         symmetry,
+        image_width,
     ):
         self.optimizer_klass = extend_with_decoupled_weight_decay(
             self.optimizer_klass,
@@ -88,11 +89,15 @@ class TFSolver(BaseSolver):
         self.model_init_fn = model_init_fn
         self.framework = framework
         self.symmetry = symmetry
+        self.image_width = image_width
 
         if self.data_aug:
             data_aug_list = [
                 tf.keras.layers.ZeroPadding2D(padding=4),
-                tf.keras.layers.RandomCrop(height=32, width=32),
+                tf.keras.layers.RandomCrop(
+                    height=self.image_width,
+                    width=self.image_width,
+                ),
             ]
             if self.symmetry is not None and 'horizontal' in self.symmetry:
                 data_aug_list.append(tf.keras.layers.RandomFlip('horizontal'))

--- a/utils/tf_solver.py
+++ b/utils/tf_solver.py
@@ -44,8 +44,6 @@ class TFSolver(BaseSolver):
         # by the learning rate to have a comparable setting with PyTorch
         self.coupled_wd = getattr(self, 'coupled_weight_decay', 0.0)
         self.decoupled_wd = getattr(self, 'decoupled_weight_decay', 0.0)
-        if self.decoupled_wd == 0.0:
-            self.decoupled_wd = getattr(self, 'weight_decay', 0.0)
         if self.lr_schedule == 'step':
             self.lr_scheduler, self.wd_scheduler = [
                 tf.keras.optimizers.schedules.PiecewiseConstantDecay(

--- a/utils/tf_solver.py
+++ b/utils/tf_solver.py
@@ -30,7 +30,15 @@ class TFSolver(BaseSolver):
     install_cmd = 'conda'
     requirements = ['pip:tensorflow-addons']
 
-    def skip(self, model_init_fn, dataset, normalization, framework, symmetry):
+    def skip(
+        self,
+        model_init_fn,
+        dataset,
+        normalization,
+        framework,
+        symmetry,
+        image_width,
+    ):
         if framework != 'tensorflow':
             return True, 'Not a TF dataset/objective'
         coupled_wd = getattr(self, 'coupled_weight_decay', 0.0)

--- a/utils/tf_solver.py
+++ b/utils/tf_solver.py
@@ -10,6 +10,9 @@ with safe_import_context() as import_ctx:
     LRWDSchedulerCallback = import_ctx.import_from(
         'tf_helper', 'LRWDSchedulerCallback'
     )
+    apply_coupled_weight_decay = import_ctx.import_from(
+        'tf_helper', 'apply_coupled_weight_decay'
+    )
 
 MAX_EPOCHS = int(1e9)
 
@@ -52,8 +55,6 @@ class TFSolver(BaseSolver):
         # by the learning rate to have a comparable setting with PyTorch
         self.coupled_wd = getattr(self, 'coupled_weight_decay', 0.0)
         self.decoupled_wd = getattr(self, 'decoupled_weight_decay', 0.0)
-        if self.decoupled_wd == 0.0:
-            self.decoupled_wd = getattr(self, 'weight_decay', 0.0)
         if self.lr_schedule == 'step':
             self.lr_scheduler, self.wd_scheduler = [
                 tf.keras.optimizers.schedules.PiecewiseConstantDecay(
@@ -154,20 +155,10 @@ class TFSolver(BaseSolver):
             # the weights and biases of the model (even if adding
             # weight decay to the biases is not recommended), of a factor
             # halved
-            l2_reg_factor = self.coupled_wd / 2
-            # taken from
-            # https://sthalles.github.io/keras-regularizer/
-            regularizer = tf.keras.regularizers.l2(l2_reg_factor)
-            target_regularizers = [
-                'kernel_regularizer',
-                'bias_regularizer',
-                'beta_regularizer',
-                'gamma_regularizer',
-            ]
-            for layer in self.model.layers:
-                for attr in target_regularizers:
-                    if hasattr(layer, attr):
-                        setattr(layer, attr, regularizer)
+            self.model = apply_coupled_weight_decay(
+                self.model,
+                self.coupled_wd,
+            )
         self.model.compile(
             optimizer=self.optimizer,
             loss='sparse_categorical_crossentropy',

--- a/utils/torch_solver.py
+++ b/utils/torch_solver.py
@@ -30,7 +30,15 @@ class TorchSolver(BaseSolver):
         'lr_schedule': [None, 'step', 'cosine'],
     }
 
-    def skip(self, model_init_fn, dataset, normalization, framework, symmetry):
+    def skip(
+        self,
+        model_init_fn,
+        dataset,
+        normalization,
+        framework,
+        symmetry,
+        image_width,
+    ):
         if framework != 'pytorch':
             return True, 'Not a torch dataset/objective'
         coupled_wd = getattr(self, 'coupled_weight_decay', 0.0)

--- a/utils/torch_solver.py
+++ b/utils/torch_solver.py
@@ -46,16 +46,18 @@ class TorchSolver(BaseSolver):
         normalization,
         framework,
         symmetry,
+        image_width,
     ):
         self.dataset = dataset
         self.model_init_fn = model_init_fn
         self.normalization = normalization
         self.framework = framework
         self.symmetry = symmetry
+        self.image_width = image_width
 
         if self.data_aug:
             data_aug_list = [
-                transforms.RandomCrop(32, padding=4),
+                transforms.RandomCrop(self.image_width, padding=4),
             ]
             if self.symmetry is not None and 'horizontal' in self.symmetry:
                 data_aug_list.append(transforms.RandomHorizontalFlip())

--- a/utils/torch_solver.py
+++ b/utils/torch_solver.py
@@ -51,12 +51,15 @@ class TorchSolver(BaseSolver):
         self.model_init_fn = model_init_fn
         self.normalization = normalization
         self.framework = framework
+        self.symmetry = symmetry
 
         if self.data_aug:
-            data_aug_transform = transforms.Compose([
+            data_aug_list = [
                 transforms.RandomCrop(32, padding=4),
-                transforms.RandomHorizontalFlip(),
-            ])
+            ]
+            if self.symmetry is not None and 'horizontal' in self.symmetry:
+                data_aug_list.append(transforms.RandomHorizontalFlip())
+            data_aug_transform = transforms.Compose(data_aug_list)
         else:
             data_aug_transform = None
         self.dataset = AugmentedDataset(

--- a/utils/torch_solver.py
+++ b/utils/torch_solver.py
@@ -30,7 +30,7 @@ class TorchSolver(BaseSolver):
         'lr_schedule': [None, 'step', 'cosine'],
     }
 
-    def skip(self, model_init_fn, dataset, normalization, framework):
+    def skip(self, model_init_fn, dataset, normalization, framework, symmetry):
         if framework != 'pytorch':
             return True, 'Not a torch dataset/objective'
         coupled_wd = getattr(self, 'coupled_weight_decay', 0.0)
@@ -39,7 +39,14 @@ class TorchSolver(BaseSolver):
             return True, 'Cannot use both decoupled and coupled weight decay'
         return False, None
 
-    def set_objective(self, model_init_fn, dataset, normalization, framework):
+    def set_objective(
+        self,
+        model_init_fn,
+        dataset,
+        normalization,
+        framework,
+        symmetry,
+    ):
         self.dataset = dataset
         self.model_init_fn = model_init_fn
         self.normalization = normalization


### PR DESCRIPTION
These corrections are needed to have exactly the same model even if they are not catchable with the current unit test.

They also do not change the final model performance.

EDIT
-----
Now only the init of models is not catchable by unit tests.
Moreover, it was really the coupled weight decay application that allowed to reach PyTorch's perf.

Unit tests are not passing in eval mode because of the difference in variance estimation for the inference between PyTorch and TensorFlow (see https://github.com/pytorch/pytorch/issues/77427#issuecomment-1126737756).
Regarding the adam test, and the sgd with momentum alone, I am not sure yet what the cause is.